### PR TITLE
add regex group for additional match in legacy scanner

### DIFF
--- a/Scanners/Series/Absolute Series Scanner (legacy).py
+++ b/Scanners/Series/Absolute Series Scanner (legacy).py
@@ -9,7 +9,7 @@ season_rx = [                                                                   
   '(([Ss]tory )?[Aa]r[kc]|[Vv]ideo).*']                                                                                                                                 # Arc|Story arc ...   #The last line matches are dropped
 series_rx = [                                                                                                                                                           ######### Series regex - "serie - xxx - title" ###
   '(^|(?P<show>.*?)[ _\.\-]+)(?P<season>[0-9]{1,2})[Xx](?P<ep>[0-9]{1,3})((|[-_][0-9]{1,2})[Xx](?P<ep2>[0-9]{1,3}))?([ _\.\-]+(?P<title>.*))?$',                        #  0 # 1x01
-  '(^|(?P<show>.*?)[ _\.\-]+)s(?P<season>[0-9]{1,2})(e| e|ep| ep|-)(?P<ep>[0-9]{1,3})(([ _\.\-]|(e|ep)|[ _\.\-](e|ep))(?P<ep2>[0-9]{1,3}))?($|( | - |)(?P<title>.*?)$)',#  1 # s01e01-02 | ep01-ep02 | e01-02
+  '(^|(?P<show>.*?)[ _\.\-]+)s(?P<season>[0-9]{1,2})([ _\.\-])?(e| e|ep| ep|)(?P<ep>[0-9]{1,3})(([ _\.\-]|(e|ep)|[ _\.\-](e|ep))(?P<ep2>[0-9]{1,3}))?($|( | - |)(?P<title>.*?)$)',#  1 # s01e01-02 | ep01-ep02 | e01-02 | s01-e01 | s01 e01
   '(?P<title>.*?) [\(]?(?P<season>(19|20)[0-9]{2})[\)]$',                                                                                                               #  2 # title (1932).ext
   '(^|(?P<show>.*?)[ _\.\-]+)(?P<ep>[0-9]{1,3})[ _\.\-]?of[ _\.\-]?[0-9]{1,3}([ _\.\-]+(?P<title>.*?))?$',                                                              #  3 # 01 of 08 (no stacking for this one ?)
   '^(?P<show>.*?) - (?P<ep>[0-9]{1,3}) - (?P<title>.*)$']                                                                                                               #  4 # Serie - xx - title.ext


### PR DESCRIPTION
If Season and Episode are seperated by a dot the episode was only catched in the 2nd episode group.
Furthermore when trying to match obscure stuff like s01-e01 and "s01 e01" the current implementation grouped all episodes in 1 Special episode. This should fix that.

Suggestions for Tests:
Dragon.Ball.Super.S01-E02.HD.ENG.SUBBED.mp4
Series.Title.S01.E02.1080p.mp4
Series Title S01 E01 1080p.mp4
Series Title S01 E01-03 1080p.mp4
Series Title S01 E01-E03 1080p.mp4

Signed-off-by: Robin Wenzel <info@robin-wenzel.de>